### PR TITLE
Update Ouverture.md

### DIFF
--- a/Ouverture.md
+++ b/Ouverture.md
@@ -57,17 +57,15 @@ Pour rappel, les licences à utiliser sont disponibles par décret sur le site :
 
 ### Recommandation d'utiliser des licences permissives dans le cas général
 
-Pour l’administration, par défaut, les licences de la famille permissives sont privilégiées afin de ne pas introduire de biais de concurrence et empêcher un acteur (commercial et propriétaire) de bénéficier du code développé par l’administration. Ainsi de nouveaux services à valeur ajoutée peuvent être développés par des acteurs tiers, même si ces derniers restent propriétaires (et payants).
+Par défaut, les licences de la famille permissives sont privilégiées par l'administration afin de faciliter la diffusion des codes sources et leur réutilisation en limitant les risques d'incompatibilités avec les licences préexistantes. Ces licences seront particulièrement adaptées pour couvrir les codes sources implémentant un service de base ou d’infrastructure qui a vocation à être inclus dans d’autres services ou appelé par d’autres services (bibliothèques, frameworks...).
 
-Toutefois, le choix d’une licence de partage à l’identique peut être pertinent dans les cas suivants pour prévenir toute appropriation propriétaire :
+Cependant, le choix d’une licence de partage à l’identique peut être pertinent dans les cas suivants pour prévenir toute appropriation propriétaire :
  *	Service d’intérêt général
  *	Service « contributif » : service en ligne dont la valeur est issue des contributions des utilisateurs du service. 
  *	Service qui organise un écosystème. Permet de partager les évolutions avec l’ensemble des acteurs.
  *	Service décentralisé qui est instancié de nombreuses fois et dont les instances doivent communiquer entre elles.
  *	Service qui établit un lien fort avec le citoyen qui doit être préservé sans que d’autres services puissent l’encapsuler
 A noter que les licences de partage à l’identique sont plus complexes notamment sur leur clause de distribution (lien statique/dynamique, accès distant, etc.)
-
-A l’inverse, si c’est un service de base ou d’infrastructure qui a vocation à être inclus dans d’autres services ou appelé par d’autres services, la balance penche plutôt pour des licences permissives.
 
 ### Pré-autorisation de signer un iCLA auprès de certaines communautés
 


### PR DESCRIPTION
Sur le § Recommandation d'utiliser des licences permissives dans le cas général

Ce paragraphe soutient que le type de licence couvrant un logiciel introduit un biais de concurrence selon le modèle économique privilégié des acteurs qui voudraient réutiliser le logiciel. 

Supposons alors que pour produire ce logiciel, l'administration doive passer un marché. Est-il possible d'exiger que le logiciel soit publiable sous licence permissive ? Non, car de la même manière certains acteurs pourraient être empêchés par cette exigence. Et même l'administration est-elle en droit d'exiger un logiciel sous licence libre, excluant de fait les éditeurs de solutions propriétaires ? 

Et cela m'amène à la décision du Conseil d'État : http://arianeinternet.conseil-etat.fr/arianeinternet/getdoc.asp?id=192208&fonds=DCE&item=1

Le Conseil d'État avait considéré qu'un marché public peut non seulement exiger du logiciel libre, mais un logiciel libre particulier sans mettre à mal la concurrence, car, « Eu égard à son caractère de logiciel libre [ce logiciel] était librement et gratuitement accessible et modifiable par l'ensemble des entreprises spécialisées [...] qui étaient ainsi toutes à même de l'adapter aux besoins de la collectivité et de présenter une offre indiquant les modalités de cette adaptation. »

Cette décision nous invite à considérer que les licences libres en attribuant à tous les mêmes droits non exclusifs réalisent en soi les conditions d'une concurrence libre et non faussée.