### PR TITLE
Correction du titre : Bonnes pratiques

### DIFF
--- a/pratique.md
+++ b/pratique.md
@@ -1,5 +1,5 @@
 ---
-title: Meilleures Pratiques
+title: Bonnes pratiques
 menuName: pratique
 ---
 


### PR DESCRIPTION
La traduction consacrée de "Best practices" est plutôt "Bonnes pratiques" que "Meilleures pratiques"