### PR TITLE
Utilisation des guillemets français

### DIFF
--- a/instanciation.md
+++ b/instanciation.md
@@ -7,7 +7,7 @@ menuName: instanciation
 ## En résumé
 
  * Possibilité d'instancier et de reprendre cette politique
- * Contacter la politique "mère" pour informer de la déclinaison
+ * Contacter la politique « mère » pour informer de la déclinaison
  * Fournir obligatoirement un moyen de contact pour la politique instanciée
 
 ## Inventaires des politiques ministérielles instanciées

--- a/pratique.md
+++ b/pratique.md
@@ -143,7 +143,7 @@ ou dans le cas d'un projet faisant un suivi automatique de ses contributeurs :
   */
 ```
 
-Ces identifiants permettent de générer automatiquement des inventaires des licences sous la forme de "Bill of Material", afin de
+Ces identifiants permettent de générer automatiquement des inventaires des licences sous la forme de « Bill of Material », afin de
 garantir la conformité du logiciel.
 
 L'ensemble des identifiants SPDX est disponible à cette adresse : [https://spdx.org/licenses/](https://spdx.org/licenses/)


### PR DESCRIPTION
Dans le texte, des guillemets droits sont utilisés à la place des guillemets français. Ce commit corrige les deux cas qui se présentent.

Je me demande cependant si l'usage des guillemets est justifié dans les deux cas. Dans le cas « Bill of rights », il me semble que l'italique devrait être préférée (on nomme un ouvrage, ce n'est pas une citation). De même pour le cas « politique « mère » », il ne s'agit pas d'une citation.