### PR TITLE
typo : majuscules doivent être accentuées et revue markdown

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,17 +1,20 @@
 LICENCE OUVERTE / OPEN LICENCE
+===================================================================
 
-Version 2.0
-Avril 2017
+- Version 2.0
+- Avril 2017
 
-« REUTILISATION » DE L’« INFORMATION » SOUS CETTE LICENCE
-==========================================================
 
-Le « Concédant » concède au « Réutilisateur » un droit non exclusif et gratuit 
+« RÉUTILISATION » DE L’« INFORMATION » SOUS CETTE LICENCE
+-------------------------------------------------------------------
+
+Le « Concédant » concède au « Réutilisateur » un droit non exclusif et gratuit
 de libre « Réutilisation » de l’« Information » objet de la présente licence,
 à des fins commerciales ou non, dans le monde entier et pour une durée
 illimitée, dans les conditions exprimées ci-dessous.
 
 Le « Réutilisateur » est libre de réutiliser l’« Information » :
+
 * de la reproduire, la copier,
 * de l’adapter, la modifier, l’extraire et la transformer, pour créer des
 « Informations dérivées », des produits ou des services,
@@ -20,6 +23,7 @@ Le « Réutilisateur » est libre de réutiliser l’« Information » :
 informations, ou en l’incluant dans son propre produit ou application.
 
 Sous réserve de :
+
 - mentionner la paternité de l’« Information » : sa source (au moins le nom du
 « Concédant ») et la date de dernière mise à jour de l’« Information »
 réutilisée.
@@ -29,6 +33,7 @@ par un lien hypertexte, vers la source de « l’Information » et assurant une
 mention effective de sa paternité.
 
 Par exemple :
+
 « Ministère de xxx - Données originales téléchargées sur
 http://www.data.gouv.fr/fr/datasets/xxx/, mise à jour du 14 février 2017 ».
 
@@ -37,21 +42,24 @@ Cette mention de paternité ne confère aucun caractère officiel à la
 reconnaissance ou caution par le « Concédant », ou par toute autre entité
 publique, du « Réutilisateur » ou de sa « Réutilisation ».
 
-« DONNEES A CARACTERE PERSONNEL »
-=================================
 
-L'« Information » mise à disposition peut contenir des « Données à caractère
+« DONNÉES À CARACTÈRE PERSONNEL »
+-------------------------------------------------------------------
+
+L’« Information » mise à disposition peut contenir des « Données à caractère
 personnel » pouvant faire l’objet d’une « Réutilisation ». Si tel est le cas,
 le « Concédant » informe le « Réutilisateur » de leur présence.
+
 L’« Information » peut être librement réutilisée, dans le cadre des droits
 accordés par la présente licence, à condition de respecter le cadre légal
 relatif à la protection des données à caractère personnel.
 
-« DROITS DE PROPRIETE INTELLECTUELLE »
-======================================
+
+« DROITS DE PROPRIÉTÉ INTELLECTUELLE »
+-------------------------------------------------------------------
 
 Il est garanti au « Réutilisateur » que les éventuels « Droits de propriété
-intellectuelle » détenus par des tiers ou par le « Concédant » sur 
+intellectuelle » détenus par des tiers ou par le « Concédant » sur
 l’« Information » ne font pas obstacle aux droits accordés par la présente
 licence.
 
@@ -62,8 +70,9 @@ exclusive, à titre gracieux, pour le monde entier, pour toute la durée des
 usage de l’« Information » conformément aux libertés et aux conditions définies
 par la présente licence.
 
-RESPONSABILITE
-==============
+
+RESPONSABILITÉ
+-------------------------------------------------------------------
 
 L’« Information » est mise à disposition telle que produite ou reçue par le
 « Concédant », sans autre garantie expresse ou tacite que celles prévues par la
@@ -79,31 +88,36 @@ l’« Information ».
 La « Réutilisation » ne doit pas induire en erreur des tiers quant au contenu
 de l’« Information », sa source et sa date de mise à jour.
 
+
 DROIT APPLICABLE
-================
+-------------------------------------------------------------------
 
 La présente licence est régie par le droit français.
 
-COMPATIBILITE DE LA PRESENTE LICENCE
-====================================
+
+COMPATIBILITÉ DE LA PRÉSENTE LICENCE
+-------------------------------------------------------------------
 
 La présente licence a été conçue pour être compatible avec toute licence libre
 qui exige au moins la mention de paternité et notamment avec la version
-antérieure de la présente licence ainsi qu’avec les licences 
-« Open Government Licence » (OGL) du Royaume-Uni,
-« Creative Commons Attribution » (CC-BY) de Creative Commons et 
-« Open Data Commons Attribution » (ODC-BY) de l’Open Knowledge Foundation.
+antérieure de la présente licence ainsi qu’avec les licences :
 
-DEFINITIONS
-===========
+- « Open Government Licence » (OGL) du Royaume-Uni,
+- « Creative Commons Attribution » (CC-BY) de Creative Commons et
+- « Open Data Commons Attribution » (ODC-BY) de l’Open Knowledge Foundation.
+
+
+DÉFINITIONS
+-------------------------------------------------------------------
 
 Sont considérés, au sens de la présente licence comme :
 
-Le « Concédant » : toute personne concédant un droit de « Réutilisation » sur 
+Le « Concédant » : toute personne concédant un droit de « Réutilisation » sur
 l’« Information » dans les libertés et les conditions prévues par la présente
 licence
 
 L’« Information » :
+
 - toute information publique figurant dans des documents communiqués ou publiés
 par une administration mentionnée au premier alinéa de l’article L.300-2 du
 CRPA;
@@ -115,7 +129,7 @@ celles pour lesquelles elle a été produite ou reçue.
 
 Le « Réutilisateur »: toute personne qui réutilise les « Informations »
 conformément aux conditions de la présente licence.
- 
+
 Des « Données à caractère personnel » : toute information se rapportant à une
 personne physique identifiée ou identifiable, pouvant être identifiée
 directement ou indirectement. Leur « Réutilisation » est subordonnée au respect
@@ -131,8 +145,9 @@ par le Code de la propriété intellectuelle (notamment le droit d’auteur, dro
 voisins au droit d’auteur, droit sui generis des producteurs de bases de
 données…).
 
+
 À PROPOS DE CETTE LICENCE
-=========================
+-------------------------------------------------------------------
 
 La présente licence a vocation à être utilisée par les administrations pour la
 réutilisation de leurs informations publiques. Elle peut également être

--- a/LICENSE
+++ b/LICENSE
@@ -15,11 +15,11 @@ illimitée, dans les conditions exprimées ci-dessous.
 
 Le « Réutilisateur » est libre de réutiliser l’« Information » :
 
-* de la reproduire, la copier,
-* de l’adapter, la modifier, l’extraire et la transformer, pour créer des
+- de la reproduire, la copier,
+- de l’adapter, la modifier, l’extraire et la transformer, pour créer des
 « Informations dérivées », des produits ou des services,
-* de la communiquer, la diffuser, la redistribuer, la publier et la transmettre,
-* de l’exploiter à titre commercial, par exemple en la combinant avec d’autres
+- de la communiquer, la diffuser, la redistribuer, la publier et la transmettre,
+- de l’exploiter à titre commercial, par exemple en la combinant avec d’autres
 informations, ou en l’incluant dans son propre produit ou application.
 
 Sous réserve de :


### PR DESCRIPTION
revue ortho-typo : 
- les majuscules doivent être accentuées
- format markdown plus strict (titres, espace après un paragraphe)

Je proposerais également de ne pas écrire les titres en majuscules.
Faudrait peut-être aussi unifier le format des listes : "*" ou "-" ?