### PR TITLE
Clarification du titre et retrait de la mention sur github.com

### DIFF
--- a/DCO-fr.txt
+++ b/DCO-fr.txt
@@ -9,7 +9,7 @@ En faisant une contribution à ce projet, j’atteste que :
     de la soumettre sous la licence applicable au projet; ou que
 
 (b) Ma contribution s’appuie sur des travaux antérieurs qui, à ma connaissance,
-    sont couverts par une licence open-source et que j’ai le droit sous cette
+    sont couverts par une licence open source et que j’ai le droit sous cette
     licence de soumettre cette contribution avec mes modifications, créées en
     tout ou partie par moi, sous la licence applicable au projet; ou que
 

--- a/faq.md
+++ b/faq.md
@@ -29,7 +29,7 @@ Si vous travaillez pour une administration au périmètre de la DINSIC, vous êt
 L'obligation d'ouverture des codes est liée à la loi République Numérique. Différents décrets d'application séquencent les obligations d'ouverture.
 
 
-## J'ai besoin d'une aide juridique sur une licence open-source, qui puis-je contacter ? 
+## J'ai besoin d'une aide juridique sur une licence Open Source, qui puis-je contacter ? 
 
 Si vous faites partie de l'administration, vous pouvez contacter l'adresse email de contact proposée dans la politique.
 

--- a/faq.md
+++ b/faq.md
@@ -6,7 +6,7 @@ menuName: faq
 
 ## Suis-je concerné(e) par cette politique de contribution open source ?
 
-Comme indiqué dans l'introduction, si la loi République Numérique s'applique à toute l'administration, le périmètre de la DINSIC se concentre sur la fonction publique d'Etat (avec quelques exceptions selon le décret n° 2014-879 du 1er août 2014). Si vous faites partie d'une collectivité territoriale, cette politique ne vous concerne pas, bien que la loi République Numérique s'applique. Si vous faites partie d'un opérateur ou d'un établissement public sous la tutelle d'un ministère, vous êtes concernés.
+Comme indiqué dans l'introduction, si la loi République Numérique s'applique à toute l'administration, le périmètre de la DINSIC se concentre sur la fonction publique d'État (avec quelques exceptions selon le décret n° 2014-879 du 1er août 2014). Si vous faites partie d'une collectivité territoriale, cette politique ne vous concerne pas, bien que la loi République Numérique s'applique. Si vous faites partie d'un opérateur ou d'un établissement public sous la tutelle d'un ministère, vous êtes concernés.
 
 
 ### et si j'appartiens à un établissement de recherche ?
@@ -21,7 +21,7 @@ Si vous intervenez dans le cadre d'un marché public, vous êtes concernés. Tou
 
 ### et si je suis indépendant / auto-entrepreneur ?
   
-Si vous travaillez pour une administration au périmètre de la DINSIC, vous êtes également concerné.
+Si vous travaillez pour une administration relevant du périmètre de la DINSIC, vous êtes également concerné.
 
 
 ## Quels sont les codes qui ont vocation à être ouvert ?
@@ -31,33 +31,34 @@ L'obligation d'ouverture des codes est liée à la loi République Numérique. D
 
 ## J'ai besoin d'une aide juridique sur une licence Open Source, qui puis-je contacter ? 
 
-Si vous faites partie de l'administration, vous pouvez contacter l'adresse email de contact proposée dans la politique.
+Si vous faites partie de l'administration, vous pouvez contacter l'adresse électronique de contact proposée dans la politique.
 
 
 ## Quelle adresse électronique utiliser pour contribuer à un projet&nbsp;?
 
-Tout est détaillé dans la page Ouverture / Attribuer les contributions aux individus
+Tout est détaillé dans la page `Ouverture / Attribuer les contributions aux individus`
 
 
 ### et si je suis salarié d'une ESN / SSII ? 
   
-Tout est détaillé dans la page Ouverture / Attribuer les contributions aux individus.
+Tout est détaillé dans la page `Ouverture / Attribuer les contributions aux individus`.
   
 
 ### et si je suis indépendant / auto-entrepreneur ?
   
-Dans ce cas précis, l'identité prime et l'utilisation d'un mail profesionnel ou personnel est équivalent. Choisissez ce que vous voulez.
+Dans ce cas précis, l'identité prime et il revient au même d'utiliser une adresse électronique professionnelle ou personnelle. Choisissez ce que vous voulez.
   
 
 ## Dois-je utiliser mon mail pro si je contribue depuis longtemps à un projet à titre personnel ?
 
-Si les contributions se font dans le cadre professionnel, il vous est effectivement demandé d'utiliser votre mail professionnel.
+Si les contributions se font dans le cadre professionnel, il vous est effectivement demandé d'utiliser votre adresse électronique professionnelle.
 
 
 ## Comment choisir parmi les différentes licences proposées ?
 
-Voici quelques exemples de choix de licences qui pourront vous guider. N'hésitez pas à revenir vers nous en utilisant l'adresse de contact pour toute question ou conseil.
- A COMPLETER
+Voir `Ouverture / Autorisation par défaut de contribuer à des projets sous licence FSF ou OSI` et `Ouverture / Autorisation par défaut de contribuer un nouveau projet avec les licences du décret`.
+
+N'hésitez pas à revenir vers nous en utilisant l'adresse de contact pour toute question ou conseil.
 
 
 ## Dois-je obtenir une validation avant de publier du code ?
@@ -73,10 +74,10 @@ Bien qu'une pré-autorisation par défaut soit proposée par la DINSIC, il peut 
 
 ## J'ai un doute sur l'ouverture d'un code source, vers qui puis-je me renseigner ?
 
-Si vous faites partie de l'administration, vous pouvez contacter l'adresse email de contact proposée dans la politique.
+Si vous faites partie de l'administration, vous pouvez contacter l'adresse électronique de contact proposée dans la politique.
 
 
 ## Puis-je coder dans une langue autre que le Français ?
 
-Le nom des variables et des fonctions, ainsi que les commentaires de code peuvent être redigés dans la langue de la communauté de développeurs visée. Toutefois, la documentation utilisateur devra être disponible en Français.  
+Le nom des variables et des fonctions, ainsi que les commentaires de code peuvent être rédigés dans la langue de la communauté de développeurs visée. Toutefois, la documentation utilisateur devra être disponible en Français.
   

--- a/pratique.md
+++ b/pratique.md
@@ -3,25 +3,11 @@ title: Bonnes pratiques
 menuName: pratique
 ---
 
-## En résumé
-
-* Utilisation nécessaire d'un système de suivi de version distribué (git, bitkeeper, mercurial) 
-* Aide au choix d'une plateforme de publication
-* Gestion des comptes personnels et d'organisation
-* Inventaire des comptes d'organisation
-* Distinction des contributions professionnelles / personnelles
-* Aide au choix de la licence
-* Gestion des versions
-* Fichiers par défaut dans un dépôt (repository)
-* Entêtes (headers) de fichiers sources
-* Traçabilité des développements (DCO)
-* Outillage
-
-## Système de suivi de version
+## Système de suivi de version de code source
 
 L'utilisation d'un système de suivi de version distribué tel que git est recommandée. Les systèmes svn ou cvs sont déconseillés.
 
-## Partage du code source sur une plateforme Web
+## Aide au choix d'une plateforme Web 
 
 En plus du système de suivi de version du code source, une plateforme Web propose une panoplie d'outils collaboratifs associés et vise à mobiliser une communauté de développeurs.  Ces plateformes peuvent être hébergées par un tiers ou par l'administration.
 

--- a/pratique.md
+++ b/pratique.md
@@ -59,7 +59,7 @@ d'organisation que de l'inventaire des services.
 
 ## Distinction des contributions personnelles / professionnelles
 
-Utilisation du compte professionnel, par exemple avec un mail en ```.gouv.fr``` ou ```.cnrs.fr```.
+Utilisation du compte professionnel, par exemple avec une adresse électronique en ```.gouv.fr``` ou ```.cnrs.fr```.
 
 Créer le dépôt, configuré de la manière suivante :
 

--- a/pratique.md
+++ b/pratique.md
@@ -21,7 +21,7 @@ menuName: pratique
 
 L'utilisation d'un système de suivi de version distribué tel que git est recommandée. Les systèmes svn ou cvs sont déconseillés.
 
-## Aide au choix d'une plateforme Web
+## Partage du code source sur une plateforme Web
 
 En plus du système de suivi de version du code source, une plateforme Web propose une panoplie d'outils collaboratifs associés et vise à mobiliser une communauté de développeurs.  Ces plateformes peuvent être hébergées par un tiers ou par l'administration.
 
@@ -34,7 +34,7 @@ Exemples de plateformes Web hébergées par un tiers :
  * FSFE : https://git.fsfe.org - utilisant [Gitea](https://gitea.io/)
  * FSF : https://git.savannah.gnu.org/cgit/ - utilisant [cgit](https://git.zx2c4.com/cgit/)
 
-Le code source de github.com n'est pas libre tout comme certains modules de gitlab.com ; certaines plateformes publient des données anonymisées en open data ; leurs portées géographiques peuvent varier, de même que le nombre de développeurs qui l'utilisent.  La liste est incomplète.  Actuellement, github.com permet d'atteindre la plus grande communauté de développeurs au plan international.
+Le code source de github.com n'est pas libre tout comme certains modules de gitlab.com ; certaines plateformes publient des données anonymisées en open data ; leurs portées géographiques peuvent varier, de même que le nombre de développeurs qui l'utilisent.  La liste est incomplète.
 
 Le choix de créer un compte d'organisation au sein d'une plateforme Web existante relève de l'administration, qui peut également héberger sa propre forge publique.
 


### PR DESCRIPTION
Le titre précédent (« Aide au choix d'une plateforme Web ») donne
l'impression que la décision de publier sur telle ou telle plateforme
revient aux développeurs (car le document s'adresse au développeurs),
alors qu'elle revient aux administrations.  Le titre proposé est plus
neutre.

Je propose aussi de retirer la mention disant que github.com rassemble
la plus grande communauté de développeurs, qui donne aussi l'impression
que le document recommande d'utiliser github.com, alors qu'une telle
recommandation vise l'administration, pas les développeurs.