### PR TITLE
corrections typo et faq dépliable 

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -2,12 +2,19 @@
 title: Foire aux questions
 weight: 70
 menuName: faq
+layout: faq
 ---
 
 ## Périmètre 
-### Suis-je concerné(e) par cette politique de contribution open source ?
 
-Comme indiqué dans l'introduction, si la loi République Numérique s'applique à toute l'administration, le périmètre de la DINSIC se concentre sur la fonction publique d'État (avec quelques exceptions selon le décret n° 2014-879 du 1er août 2014). Si vous faites partie d'une collectivité territoriale, cette politique ne vous concerne pas, bien que la loi République Numérique s'applique. Si vous faites partie d'un opérateur ou d'un établissement public sous la tutelle d'un ministère, vous êtes concerné.
+
+{{% question "Suis-je concerné(e) par cette politique de contribution open source ?"%}}
+
+Comme indiqué dans l'introduction, si la loi République Numérique s'applique à toute l'administration, le périmètre de la DINSIC se concentre sur la fonction publique d'État (avec quelques exceptions selon le décret n° 2014-879 du 1er août 2014). 
+
+Si vous faites partie d'une collectivité territoriale, cette politique ne vous concerne pas, bien que la loi République Numérique s'applique. 
+
+Si vous faites partie d'un opérateur ou d'un établissement public sous la tutelle d'un ministère, vous êtes concerné.
 
 
 #### et si j'appartiens à un établissement de recherche ?
@@ -24,12 +31,15 @@ Si vous intervenez dans le cadre d'un marché public, vous êtes concernés. Tou
 
 Si vous travaillez pour une administration relevant du périmètre de la DINSIC, vous êtes également concerné.
 
+{{% /question %}}
 
-### Quels sont les codes qui ont vocation à être ouverts ?
+{{% question "Quels sont les codes qui ont vocation à être ouverts ?" %}}
 
 L'obligation d'ouverture des codes est liée à la loi République Numérique qui prévoit une ouverture progressive jusqu'au 7 octobre 2018. A
 cette date, une ouverture par défaut est prévue pour tous les codes qui revêtent un intérêt économique, social, 
-sanitaire ou environnemental. Tout code écrit dans le cadre d'une mission de service publique est potentiellement communicable et réutilisable à d'autres fins, aux exceptions suivantes près : 
+sanitaire ou environnemental. 
+
+Tout code écrit dans le cadre d'une mission de service publique est potentiellement communicable et réutilisable à d'autres fins, aux exceptions suivantes près : 
 
 - Le code doit être achevé (i.e. mis en production)
 - Sa communication ne doit pas porter atteinte à : 
@@ -37,62 +47,90 @@ sanitaire ou environnemental. Tout code écrit dans le cadre d'une mission de se
     - La sûreté de l'État, la sécurité publique, des personnes  ou des systèmes d'information des administrations
     - La recherche ou la prévention d'infractions de toute nature
 
-### J'ai un doute sur l'ouverture d'un code source, vers qui puis-je me renseigner ?
+{{% /question %}}
+
+{{% question "J'ai un doute sur l'ouverture d'un code source, vers qui puis-je me renseigner ?" %}}
 
 Vous pouvez contacter l'adresse électronique de contact proposée dans la politique.
+
+{{% /question %}}
 
 
 ## Licences
 
-### Comment choisir parmi les différentes licences proposées ?
+{{% question "Comment choisir parmi les différentes licences proposées ?" %}}
 
-Voir `Ouverture / Autorisation par défaut de contribuer à des projets sous licence FSF ou OSI` et `Ouverture / Autorisation par défaut de contribuer un nouveau projet avec les licences du décret`.
+Voir [Ouverture / Autorisation par défaut de contribuer à des projets sous licence FSF ou OSI]({{< relref "ouverture.md#autorisation-par-défaut-de-contribuer-à-des-projets-sous-licence-fsf-ou-osi" >}} ) et [Ouverture / Autorisation par défaut de contribuer un nouveau projet avec les licences du décret]({{< relref "ouverture.md#autorisation-par-défaut-de-contribuer-un-nouveau-projet-avec-les-licences-du-décret" >}} ).
 
 N'hésitez pas à revenir vers nous en utilisant l'adresse de contact pour toute question ou conseil.
 
-### J'ai besoin d'une aide juridique sur une licence Open Source, qui puis-je contacter ?
+{{% /question %}}
+
+{{% question "J'ai besoin d'une aide juridique sur une licence Open Source, qui puis-je contacter ?" %}}
 
 Vous pouvez contacter l'adresse électronique de contact proposée dans la politique.
 
-## Identité électronque
+{{% /question %}}
 
-### Quelle adresse électronique utiliser pour contribuer à un projet ?
 
-Tout est détaillé dans la page `Ouverture / Attribuer les contributions aux individus`
+## Identité électronique
 
+{{% question "Quelle adresse électronique utiliser pour contribuer à un projet ?" %}}
+
+Tout est détaillé dans la page [Ouverture / Attribuer les contributions aux individus]({{< relref "ouverture.md#attribuer-les-contributions-aux-individus" >}} ).
 
 #### et si je suis salarié d'une ESN / SSII ?
 
-Tout est détaillé dans la page `Ouverture / Attribuer les contributions aux individus`.
+Tout est détaillé dans la page [Ouverture / Attribuer les contributions aux individus]({{< relref "ouverture.md#attribuer-les-contributions-aux-individus" >}} ).
 
 
 #### et si je suis indépendant / auto-entrepreneur ?
 
 Dans ce cas précis, l'identité prime et il revient au même d'utiliser une adresse électronique professionnelle ou personnelle. Choisissez ce que vous voulez.
 
+{{% /question %}}
 
-### Dois-je utiliser mon mail pro si je contribue depuis longtemps à un projet à titre personnel ?
+
+{{% question "Dois-je utiliser mon mail pro si je contribue depuis longtemps à un projet à titre personnel ?" %}}
 
 Si les contributions se font dans le cadre professionnel, il vous est effectivement demandé d'utiliser votre adresse électronique professionnelle.
+
+{{% /question %}}
+
 
 
 ## Divers
 
-### Dois-je obtenir une validation avant de publier du code ?
+{{% question "Dois-je obtenir une validation avant de publier du code ?" %}}
 
 Bien qu'une pré-autorisation par défaut soit proposée par la DINSIC, il peut être nécessaire d'obtenir l'accord de votre supérieur hiérarchique.
 
-### Mon administration n'a pas de compte d'organisation sur le service en ligne d'hébergement de code que je souhaite utiliser. Que faire ?
+{{% /question %}}
 
-Si votre administration dispose d'un compte sur une autre plate-forme, contactez le responsable de ce compte. Si ce n'est pas le cas, contactez l'adresse électronique de contact proposée dans la politique.
 
-### Je n'ose pas faire mon premier commit en public, puis-je obtenir de l'aide ?
+{{% question "Mon administration n'a pas de compte d'organisation sur le service en ligne d'hébergement de code que je souhaite utiliser. Que faire ?" %}} 
 
-Si vous avez une contribution disponible sur un dépôt privé, il est possible et encouragé de demander une revue par les pairs. Nous vous
-conseillons d'identifier quelqu'un au plus proche de votre structure qui a déjà contribué publiquement pour qu'il puisse vous aider. Si 
-toutefois vous ne parvenez pas à identifier quelqu'un, vous pouvez contacter l'adresse électronique de contact proposée dans la politique
+Si votre administration dispose d'un compte sur une autre plate-forme, contactez le responsable de ce compte. 
+
+Si ce n'est pas le cas, contactez l'adresse électronique de contact proposée dans la politique.
+
+{{% /question %}}
+
+
+{{% question "Je n'ose pas faire mon premier commit en public, puis-je obtenir de l'aide ?" %}}
+
+Si vous avez une contribution disponible sur un dépôt privé, il est possible et encouragé de demander une revue par les pairs. 
+
+Nous vous conseillons d'identifier quelqu'un au plus proche de votre structure qui a déjà contribué publiquement pour qu'il puisse vous aider. 
+
+Si toutefois vous ne parvenez pas à identifier quelqu'un, vous pouvez contacter l'adresse électronique de contact proposée dans la politique
 pour que nous puissions vous aider à trouver des pairs.
 
-### Puis-je coder dans une langue autre que le français ?
+{{% /question %}}
+
+
+{{% question "Puis-je coder dans une langue autre que le français ?" %}}
 
 Le nom des variables et des fonctions, ainsi que les commentaires de code peuvent être rédigés dans la langue de la communauté de développeurs visée. Toutefois, la documentation utilisateur devra être disponible en français.
+
+{{% /question %}}

--- a/introduction.md
+++ b/introduction.md
@@ -79,11 +79,11 @@ Ce document a été élaboré grâce aux nombreux travaux ci-dessous :
  * Linux Foundation Open Source Guides : 
  <br>[https://www.linuxfoundation.org/resources/open-source-guides/](https://www.linuxfoundation.org/resources/open-source-guides/)
  * Core Infrastructure Initiative : 
- <br>[https://bestpractices.coreinfrastructure.org/](https://bestpractices.coreinfrastructure.org/)
+ <br>[https://bestpractices.coreinfrastructure.org](https://bestpractices.coreinfrastructure.org/)
  * Open Source Guides : 
- <br>[https://opensource.guide/](https://opensource.guide/)
+ <br>[https://opensource.guide](https://opensource.guide/)
  * FSFE software reuse : 
- <br>[https://reuse.software/](https://reuse.software/)
+ <br>[https://reuse.software](https://reuse.software/)
  * Google Open Source : 
  <br>[http://opensource.google.com](http://opensource.google.com)
 

--- a/pratique.md
+++ b/pratique.md
@@ -145,10 +145,11 @@ Pour l'instant, le sign-off ne se fait qu'en anglais en utilisant la commande
 
 ## Bonnes pratiques de développement
 
-Les bonnes pratiques de développement courantes s'appliquent également en contexte de développement ouvert, et notamment celles liées au respect des référentiels en vigueur dans l'administration
- * [Référentiel général d'interopérabilité](http://references.modernisation.gouv.fr/interoperabilite)
- * [Référentiel général d'accessibilité pour les administrations](http://references.modernisation.gouv.fr/rgaa-accessibilite/)
- * [Référentiel général de sécurité](https://www.ssi.gouv.fr/administration/reglementation/confiance-numerique/le-referentiel-general-de-securite-rgs/)
+Les bonnes pratiques de développement courantes s'appliquent également en contexte de développement ouvert, et notamment celles liées au respect des référentiels en vigueur dans l'administration :
+
+* [Référentiel général d'interopérabilité](http://references.modernisation.gouv.fr/interoperabilite)
+* [Référentiel général d'accessibilité pour les administrations](http://references.modernisation.gouv.fr/rgaa-accessibilite/)
+* [Référentiel général de sécurité](https://www.ssi.gouv.fr/administration/reglementation/confiance-numerique/le-referentiel-general-de-securite-rgs/)
 
 L'ouverture du code vient par ailleurs amplifier l'importance de certaines de ces bonnes pratiques : 
 

--- a/pratique.md
+++ b/pratique.md
@@ -113,7 +113,6 @@ doit disposer de son auteur, de son identifiant de licence SPDX, ainsi que d'une
   * SPDX-License-Identifier: BSD-2-Clause
   * License-Filename: LICENSES/BSD-2-Clause_Alice.txt
   */
-
 ```
 
 ou dans le cas d'un projet faisant un suivi automatique de ses contributeurs :


### PR DESCRIPTION
Quelques corrections typo et ajout du code pour permettre de rendre pliable / dépliable les questions de premier niveau de la faq.

