### PR TITLE
Version 1.0RC01 soumise à validation

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -103,7 +103,7 @@ Si les contributions se font dans le cadre professionnel, il vous est effectivem
 
 {{% question "Dois-je obtenir une validation avant de publier du code ?" %}}
 
-Bien qu'une pré-autorisation par défaut soit proposée par la DINSIC, il peut être nécessaire d'obtenir l'accord de votre supérieur hiérarchique.
+Bien qu'une pré-autorisation par défaut soit proposée par la DINSIC, il peut être nécessaire d'obtenir l'accord de votre supérieur hiérarchique (au même titre que vous faites valider vos formations proposées par le service formation). Pour la publication d'une nouvelle base de code et pas une contribution à un code existant, vous deverez obtenir un dépôt sur le compte de votre organisation.
 
 {{% /question %}}
 

--- a/introduction.md
+++ b/introduction.md
@@ -11,8 +11,9 @@ __Historique et versions__
 | 0.1     | Initialisation                                  | 01/11/2017 |
 | 0.2     | Ouverture de l'appel à commentaires             | 06/12/2017 |
 | 0.3     | Fin de l'appel à commentaires                   | 28/01/2018 |
+| 1.0RC01 | Projet soumi à validation                       | 10/02/2018 |
 
-Ce document est en __beta__, c'est à dire avec des modifications possibles sans nécessairement de changement de numéro de version.
+Ce document est en cours de validation. Il reste pour l'instant en __beta__, et peut évoluer encore fréquemment.
 
 ## Objectifs
 


### PR DESCRIPTION
En vue de la validation au prochain CSIC-Tech du 15 février 2018, ce projet de politique de contribution est soumis à l'ensemble des mainteneurs.

Nous devons obtenir au moins 3 Approve pour fusionner sur master et permettre de générer l'HTML.

Il est possible de compléter cette pull-request avec des modifications supplémentaires si nécessaire.