### PR TITLE
Mise en liens des urls brutes

### DIFF
--- a/introduction.en.md
+++ b/introduction.en.md
@@ -68,28 +68,17 @@ This document is published under the [Open License 2.0][LO link]
 
 This document was developed thanks to the many works below:
 
- * Open Government Partnership collaboration:
- <br> [https://github.com/DISIC/foss-contrib-policy-template](https://github.com/DISIC/foss-contrib-policy-template)
- * USA 18F Open Source Policy:
- <br> [https://github.com/18F/open-source-policy/blob/master/CONTRIBUTING.md](https://github.com/18F/open-source-policy/blob/master/CONTRIBUTING .md)
- * Whitehouse Source Code Policy:
- <br> [https://sourcecode.cio.gov](https://sourcecode.cio.gov)
- * UK GDS (Government Digital Service):
- <br> [http://gds-operations.github.io/guidelines/](http://gds-operations.github.io/guidelines/)
- * Canada British Columbia:
- <br> [https://github.com/bcgov/BC-Policy-Framework-For-GitHub](https://github.com/bcgov/BC-Policy-Framework-For-GitHub)
- * Australia Digital Transformation Agency:
- <br> [https://www.dta.gov.au/standard/8-make-source-code-open/](https://www.dta.gov.au/standard/8-make-source- open-code/)
- * Linux Foundation Open Source Guides:
- <br> [https://www.linuxfoundation.org/resources/open-source-guides/](https://www.linuxfoundation.org/resources/open-source-guides/)
- * Core Infrastructure Initiative:
- <br> [https://bestpractices.coreinfrastructure.org](https://bestpractices.coreinfrastructure.org/)
- * Open Source Guides:
- <br> [https://opensource.guide](https://opensource.guide/)
- * FSFE software reuse:
- <br> [https://reuse.software](https://reuse.software/)
- * Google Open Source:
- <br> [http://opensource.google.com](http://opensource.google.com)
+ * [Open Government Partnership collaboration](https://github.com/DISIC/foss-contrib-policy-template)
+ * [USA 18F Open Source Policy](https://github.com/18F/open-source-policy/blob/master/CONTRIBUTING.md)
+ * [Whitehouse Source Code Policy](https://sourcecode.cio.gov)
+ * [UK GDS (Government Digital Service)](http://gds-operations.github.io/guidelines/)
+ * [Canada British Columbia](https://github.com/bcgov/BC-Policy-Framework-For-GitHub)
+ * [Australia Digital Transformation Agency](https://www.dta.gov.au/standard/8-make-source-code-open/)
+ * [Linux Foundation Open Source Guides](https://www.linuxfoundation.org/resources/open-source-guides/)
+ * [Core Infrastructure Initiative](https://bestpractices.coreinfrastructure.org)
+ * [Open Source Guides](https://opensource.guide)
+ * [FSFE software reuse](https://reuse.software)
+ * [Google Open Source](http://opensource.google.com)
 
 Work is also underway by the Government of Canada: [https://github.com/canada-ca/Open_First_Whitepaper](https://github.com/canada-ca/Open_First_Whitepaper)
 

--- a/introduction.md
+++ b/introduction.md
@@ -66,28 +66,17 @@ Ce document est publié sous la [**Licence Ouverte 2.0**][LO link]
 
 Ce document a été élaboré grâce aux nombreux travaux ci-dessous :
 
- * Open Government Partnership collaboration : 
- <br>[https://github.com/DISIC/foss-contrib-policy-template](https://github.com/DISIC/foss-contrib-policy-template)
- * USA 18F Open Source Policy : 
- <br>[https://github.com/18F/open-source-policy/blob/master/CONTRIBUTING.md](https://github.com/18F/open-source-policy/blob/master/CONTRIBUTING.md)
- * Whitehouse Source Code Policy : 
- <br>[https://sourcecode.cio.gov](https://sourcecode.cio.gov)
- * UK GDS (Governement Digital Service) : 
- <br>[http://gds-operations.github.io/guidelines/](http://gds-operations.github.io/guidelines/)
- * Canada British Columbia : 
- <br>[https://github.com/bcgov/BC-Policy-Framework-For-GitHub](https://github.com/bcgov/BC-Policy-Framework-For-GitHub)
- * Australia Digital Transformation Agency : 
- <br>[https://www.dta.gov.au/standard/8-make-source-code-open/](https://www.dta.gov.au/standard/8-make-source-code-open/)
- * Linux Foundation Open Source Guides : 
- <br>[https://www.linuxfoundation.org/resources/open-source-guides/](https://www.linuxfoundation.org/resources/open-source-guides/)
- * Core Infrastructure Initiative : 
- <br>[https://bestpractices.coreinfrastructure.org](https://bestpractices.coreinfrastructure.org/)
- * Open Source Guides : 
- <br>[https://opensource.guide](https://opensource.guide/)
- * FSFE software reuse : 
- <br>[https://reuse.software](https://reuse.software/)
- * Google Open Source : 
- <br>[http://opensource.google.com](http://opensource.google.com)
+ * [Open Government Partnership collaboration](https://github.com/DISIC/foss-contrib-policy-template)
+ * [USA 18F Open Source Policy](https://github.com/18F/open-source-policy/blob/master/CONTRIBUTING.md)
+ * [Whitehouse Source Code Policy](https://sourcecode.cio.gov)
+ * [UK GDS (Government Digital Service)](http://gds-operations.github.io/guidelines/)
+ * [Canada British Columbia](https://github.com/bcgov/BC-Policy-Framework-For-GitHub)
+ * [Australia Digital Transformation Agency](https://www.dta.gov.au/standard/8-make-source-code-open/)
+ * [Linux Foundation Open Source Guides](https://www.linuxfoundation.org/resources/open-source-guides/)
+ * [Core Infrastructure Initiative](https://bestpractices.coreinfrastructure.org)
+ * [Open Source Guides](https://opensource.guide)
+ * [FSFE software reuse](https://reuse.software)
+ * [Google Open Source](http://opensource.google.com)
 
 Un travail est également en cours par le gouvernement du Canada : [https://github.com/canada-ca/Open_First_Whitepaper](https://github.com/canada-ca/Open_First_Whitepaper)
 

--- a/ouverture.en.md
+++ b/ouverture.en.md
@@ -43,8 +43,8 @@ professional time must be associated with a professional email address.
 Contributions to existing projects with FSF or OSI licenses are allowed by default.
 Licenses validated by the Free Software Foundation and Open Source Initiative and listed on their respective pages:
 
-* FSF: https://www.gnu.org/licenses/license-list.fr.html (excluding non-free licenses presented as such);
-* OSI: https://opensource.org/licenses/alphabetical.
+* FSF: [https://www.gnu.org/licenses/license-list.fr.html](https://www.gnu.org/licenses/license-list.fr.html) (excluding non-free licenses presented as such);
+* OSI: [https://opensource.org/licenses/alphabetical](https://opensource.org/licenses/alphabetical).
 
 
 Conversely, licenses not retained by these organizations (such as * Beerware *) do not fall under the default authorization.
@@ -79,7 +79,7 @@ The state is not intended to be a software editor. Apart from the three exceptio
 support e-mail address in case of question, there is no prior authorization required from the DINSIC. However, please refer to your supervisor
 before publishing a new project in your organization's account.
 
-As a reminder, the licenses to use are available by decree on the site: http://www.data.gouv.fr/fr/licences.
+As a reminder, the licenses to use are available by decree on the site: [http://www.data.gouv.fr/fr/licences](http://www.data.gouv.fr/fr/licences).
 
 ### Elements to consider when choosing a free/open-source software license
 

--- a/ouverture.md
+++ b/ouverture.md
@@ -40,8 +40,8 @@ Il est possible pour un développeur de contribuer sur un même projet dans le c
 
 Les licences validées par les organismes Free Software Foundation et Open Source Initiative et recensées sur leurs pages respectives :
 
- * FSF : https://www.gnu.org/licenses/license-list.fr.html (en excluant les licences non libres présentées comme telles) ;
- * OSI : https://opensource.org/licenses/alphabetical.
+ * FSF : [https://www.gnu.org/licenses/license-list.fr.html](https://www.gnu.org/licenses/license-list.fr.html) (en excluant les licences non libres présentées comme telles) ;
+ * OSI : [https://opensource.org/licenses/alphabetical](https://opensource.org/licenses/alphabetical).
 
 À l'inverse les licences non retenues par ces organismes (comme la *Beerware*) ne rentrent pas dans le cadre de l'autorisation par défaut. Un tableau consolidé des licences validées par l'un ou l'autre organisme est maintenu sur le site [https://spdx.org/licenses/](https://spdx.org/licenses)
 
@@ -70,7 +70,7 @@ Liste des CCLA signés:
 
 L'État n'a pas vocation à être éditeur de logiciels. En dehors des trois exceptions prévues à la loi pour une République numérique pour lesquelles vous pouvez contacter l'adresse électronique de support en cas de question, il n'y a pas d'autorisation préalable à demander auprès de la DINSIC. Pour autant, veuillez vous référer à votre supérieur hiérarchique avant la publication d'un nouveau projet dans le compte de votre organisation.
 
-Pour rappel, les licences à utiliser sont disponibles par décret sur le site : http://www.data.gouv.fr/fr/licences.
+Pour rappel, les licences à utiliser sont disponibles par décret sur le site : [http://www.data.gouv.fr/fr/licences](http://www.data.gouv.fr/fr/licences).
 
 ### Éléments à considérer dans le choix de la licence libre
 

--- a/pratique.en.md
+++ b/pratique.en.md
@@ -17,12 +17,12 @@ a community of developers. These platforms may be hosted by a third party or by 
 
 Examples of web platforms hosted by a third party:
 
-* Github: https://github.com
-* Gitlab: http://gitlab.com (enterprise version)
-* Framagit: http://framagit.org - using [Gitlab](https://about.gitlab.com/installation/)
-* Adullact: http://gitlab.adullact.net - using [Gitlab](https://about.gitlab.com/installation/)
-* FSFE: https://git.fsfe.org - using [Gitea](https://gitea.io/)
-* FSF: https://git.savannah.gnu.org/cgit/ - using [cgit](https://git.zx2c4.com/cgit/)
+* Github: [https://github.com](https://github.com)
+* Gitlab: [http://gitlab.com](http://gitlab.com) (enterprise version)
+* Framagit: [http://framagit.org](http://framagit.org) - using [Gitlab](https://about.gitlab.com/installation/)
+* Adullact: [http://gitlab.adullact.net](http://gitlab.adullact.net) - using [Gitlab](https://about.gitlab.com/installation/)
+* FSFE: [https://git.fsfe.org](https://git.fsfe.org) - using [Gitea](https://gitea.io/)
+* FSF: [https://git.savannah.gnu.org/cgit/](https://git.savannah.gnu.org/cgit/) - using [cgit](https://git.zx2c4.com/cgit/)
 
 The source code of github.com is not free just like some modules of gitlab.com; some platforms publish anonymous data in open data; 
 their geographic scope may vary, as well as the number of developers who use it. The list is incomplete.
@@ -242,4 +242,4 @@ verification](https://github.com/blog/2144-gpg-signature-verification))
 
 ## Tools
 
-The contribution policy is not intended to offer specific tools. However specifically for managing open code, you can find the referenced tools on https://www.linuxfoundation.org/tools-managing-open-source-programs/#1 useful.
+The contribution policy is not intended to offer specific tools. However specifically for managing open code, you can find the referenced tools on [https://www.linuxfoundation.org/tools-managing-open-source-programs/](https://www.linuxfoundation.org/tools-managing-open-source-programs/#1) useful.

--- a/pratique.md
+++ b/pratique.md
@@ -243,4 +243,4 @@ La sécurité par l'obscurité est globalement reconnue comme une pratique insuf
 ## Outillage
 
 La politique de contribution n'a pas vocation à proposer un outillage particulier. Toutefois spécifiquement pour la gestion
-de code ouvert, vous pourrez trouver les outils référencés sur https://www.linuxfoundation.org/tools-managing-open-source-programs/#1 utiles.
+de code ouvert, vous pourrez trouver les outils référencés sur [https://www.linuxfoundation.org/tools-managing-open-source-programs/](https://www.linuxfoundation.org/tools-managing-open-source-programs/#1) utiles.


### PR DESCRIPTION
Voir ce [ticket](https://github.com/DISIC/politique-de-contribution-open-source/issues/104).

Le but est de rendre cliquables les liens sur https://www.numerique.gouv.fr/publications/politique-logiciel-libre/