### PR TITLE
Ajout du SNOSAN

### DIFF
--- a/OrgAccounts
+++ b/OrgAccounts
@@ -28,3 +28,4 @@ https://github.com/StartupsPoleEmploi
 https://adullact.net/projects/ines-libre/
 https://github.com/numerique-gouv
 https://github.com/opendatateam
+https://github.com/snosan-tools


### PR DESCRIPTION
SNOSAN : Observatoire accidentologie plaisance et loisirs nautiques France
