### PR TITLE
Corrections marginales

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -3,7 +3,6 @@
 DINSIC :
 
  * Laurent Joubert (ljoubert)
- * Maud Choquet (mchoquet)
  * Jean-Séverin Lair (JSLair)
  * Bastien Guerry (bzg)
 

--- a/pratique.en.md
+++ b/pratique.en.md
@@ -35,6 +35,8 @@ All projects initiated by an administration must be published in repositories un
  
 It is recommended to have two owners by repository.
 
+It is recommended that usernames of the organization accounts' owners are publicly accessible.
+
 ## Inventory of organization accounts
 
 Work is underway on the ability to provide an automatic inventory both from the point of view of organizations' repositories than services' inventory

--- a/pratique.md
+++ b/pratique.md
@@ -35,6 +35,8 @@ Tous les projets initiés par une administration doivent être publiés dans des
 
 Il est recommandé d'avoir deux propriétaires par dépôt.
 
+Il est recommandé que les noms d'utilisateurs des propriétaires des comptes d'organisation apparaissent publiquement.
+
 ## Inventaire des comptes d'organisation
 
 Des réflexions sont en cours sur la capacité de proposer un inventaire automatique tant du point de vue des dépôts d'organisation que de l'inventaire des services.


### PR DESCRIPTION
- Recommandation sur la visibilité des noms d'utilisateur des comptes d'organisation
- Suppression de mchoquet de la liste des mainteneurs DINSIC