### PR TITLE
Lien cassé vers MAINTAINERS

### DIFF
--- a/gouvernance.en.md
+++ b/gouvernance.en.md
@@ -13,7 +13,7 @@ Two types of organizations are distinguished:
 * Interdepartmental: DINSIC and ANSSI
 * Ministry
 
-with only one role per organization (write permission on this policy). All contributors with write permissions are listed in the [MAINTAINERS](/MAINTAINERS) file.
+with only one role per organization (write permission on this policy). All contributors with write permissions are listed in the [MAINTAINERS](https://github.com/DISIC/politique-de-contribution-open-source/blob/master/MAINTAINERS) file.
 
 ## Management of contributions
 

--- a/gouvernance.md
+++ b/gouvernance.md
@@ -13,7 +13,7 @@ Deux types d'organisations sont distinguées :
 * Interministériel : DINSIC et ANSSI
 * Ministèriel
 
-avec un seul rôle par organisation (droit d'écriture sur cette politique). L'ensemble des contributeurs avec les droits d'écriture sont listés dans le fichier [MAINTAINERS](MAINTAINERS).
+avec un seul rôle par organisation (droit d'écriture sur cette politique). L'ensemble des contributeurs avec les droits d'écriture sont listés dans le fichier [MAINTAINERS](https://github.com/DISIC/politique-de-contribution-open-source/blob/master/MAINTAINERS).
 
 ## Gestion des contributions
 


### PR DESCRIPTION
Le lien vers la page MAINTAINERS est rompu lors de la publication sur https://www.numerique.gouv.fr/publications/politique-logiciel-libre/gouvernance/ comme le chemin est relatif.

Cette PR remplace le lien par un lien complet