### PR TITLE
Ajouts de comptes depuis government.github.com

### DIFF
--- a/comptes-organismes-publics
+++ b/comptes-organismes-publics
@@ -68,3 +68,12 @@ https://git.unicaen.fr/explore/projects
 https://github.com/Irstea
 https://github.com/CNRS-DSI-Dev/
 https://github.com/atlanmod
+https://github.com/AlsaceDigitale
+https://github.com/DREAL-NA
+https://github.com/Inist-CNRS
+https://github.com/clipos
+https://github.com/erasme
+https://github.com/nanterre
+https://github.com/nantesmetropole
+https://github.com/region-bretagne
+https://github.com/strasbourg


### PR DESCRIPTION
Quelques comptes qui étaient répertoriés là-bas (https://github.com/github/government.github.com/blob/gh-pages/_data/governments.yml#L221) et non ici