### PR TITLE
Retrait d'AFBdataviz

### DIFF
--- a/comptes-organismes-publics
+++ b/comptes-organismes-publics
@@ -8,7 +8,6 @@ https://framagit.org/openfisca
 https://framagit.org/parcoursup
 https://gforge.inria.fr
 https://git.unistra.fr
-https://github.com/AFB-dataviz
 https://github.com/ANSSI-FR
 https://github.com/ARCEP-dev
 https://github.com/ApieFrance


### PR DESCRIPTION
AFBDataviz est un compte utilisateur mais n'est pas un compte d'organisation