### PR TITLE
retrait SMART PLU et ajout Géographie cités

### DIFF
--- a/comptes-organismes-publics
+++ b/comptes-organismes-publics
@@ -24,6 +24,7 @@ https://github.com/DGFiP
 https://github.com/DGTresor
 https://github.com/DREAL-NA
 https://github.com/EDS-APHP
+https://github.com/Geographie-cites
 https://github.com/Ifsttar
 https://github.com/IGNF
 https://github.com/INRA
@@ -44,7 +45,6 @@ https://github.com/PnEcrins
 https://github.com/PnX-SI
 https://github.com/PrefectureDePolice
 https://github.com/ProgrammeVitam
-https://github.com/SmartPLU
 https://github.com/SocialGouv
 https://github.com/SocieteNumerique
 https://github.com/StartupsPoleEmploi


### PR DESCRIPTION
SmartPLU n'est pas un compte organisation
Géographie cités est une UMR donc rentre dans le scope à mon avis