### PR TITLE
add the CRE OS organization

### DIFF
--- a/comptes-organismes-publics
+++ b/comptes-organismes-publics
@@ -203,4 +203,5 @@ https://gitub.u-bordeaux.fr
 https://sourcesup.renater.fr
 https://github.com/AFB-dataviz
 https://github.com/cre-dev
+https://github.com/cre-os
 https://gitlab.com/op18-enki


### PR DESCRIPTION
https://github.com/cre-os is the github organization for the "commission de régulation de l'énergie" (source https://www.cre.fr/Actualites/outils-pedagogiques-de-visualisation). The CRE is a public organization (see here https://lannuaire.service-public.fr/autorites-independantes/autorite-administrative-independante_172168))