### PR TITLE
Ajout compte Gitlab du PEReN

### DIFF
--- a/comptes-organismes-publics
+++ b/comptes-organismes-publics
@@ -211,3 +211,4 @@ https://gitlab.adullact.net/dgfip
 https://github.com/dsi-ehess
 https://github.com/pass-culture
 https://gitlab.com/rdes_dreal
+https://gitlab.com/peren/


### PR DESCRIPTION
Bonjour,

Ajout du compte Gitlab du PEReN (https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000042297154/).

Au passage, est-ce que les sous-projets Gitlab sont bien gérés par l'outil ?

Bonne journée,