### PR TITLE
Ajout de datagir

### DIFF
--- a/comptes-organismes-publics
+++ b/comptes-organismes-publics
@@ -229,3 +229,4 @@ https://github.com/ocaml
 https://github.com/Antique-team
 https://gricad-gitlab.univ-grenoble-alpes.fr
 https://github.com/gip-recia
+https://github.com/datagir


### PR DESCRIPTION
Qui sommes-nous ? datagir.ademe.fr
Anciennement hébergé chez betagouv, nous commençons à avoir tellement de dépôts qu'on ne s'y retrouve plus, et le préfixe datagir-mondépôt devenait systématique.