### PR TITLE
New Framagit's account for DG Tresor

### DIFF
--- a/comptes-organismes-publics
+++ b/comptes-organismes-publics
@@ -7,6 +7,7 @@ https://forge.grandlyon.com
 https://forge.univ-lyon1.fr
 https://forgemia.inra.fr
 https://framagit.org/datatourisme
+https://framagit.org/DGTresor
 https://framagit.org/etalab
 https://framagit.org/openfisca
 https://framagit.org/parcoursup


### PR DESCRIPTION
New account for DG Tresor (https://lannuaire.service-public.fr/gouvernement/administration-centrale-ou-ministere_171762).